### PR TITLE
Update/generalize paths for GFSv17 COM reorg

### DIFF
--- a/scripts/exgfs_tc_genesis.sh
+++ b/scripts/exgfs_tc_genesis.sh
@@ -8,7 +8,7 @@ export cmodel=gfs
 #export gfsdir=${COMINgfs}
 export COMPONENT=${COMPONENT:-atmos}
 #export gfsdir=${COMINgfs}/${cyc}/${COMPONENT}
-export gfsdir=${gfsdir:-${COMINgfs}/${cyc}/${COMPONENT}}
+export gfsdir=${gfsdir:-${COMINgfs}}
 
 #-----------input data checking -----------------
 ${USHens_tracker}/data_check_gfs.sh

--- a/ush/extrkr_fsu.sh
+++ b/ush/extrkr_fsu.sh
@@ -38,9 +38,7 @@ cd $TRKDATA
 #unlink $HOMEens_tracker/tclogg/genesis_guidance/model_config.cfg
 #ln -sf ${namelist} $HOMEens_tracker/tclogg/genesis_guidance/model_config.cfg
 
-#export file_name=${gfsdir}/gfs.{date:%Y%m%d}/{date:%H}/gfs.t{date:%H}z.pgrb2.0p25.f{fhr:03}
-export COMPONENT=${COMPONENT:-atmos}
-export file_name=${gfsdir}/gfs.{date:%Y%m%d}/{date:%H}/${COMPONENT}/gfs.t{date:%H}z.pgrb2.0p25.f{fhr:03}
+export file_name=${gfsdir/${PDY}\/${cyc}/'{date:%Y%m%d}/{date:%H}'}/gfs.t{date:%H}z.pgrb2.0p25.f{fhr:03}
 ${BINens_tracker}/tclogg_track --date ${ymdh} --odir $TRKDATA --fname_template=${file_name}
 
 #if [ "$SENDCOM" = 'YES' ]; then

--- a/ush/extrkr_gfs.sh
+++ b/ush/extrkr_gfs.sh
@@ -151,7 +151,7 @@ case ${cmodel} in
        echo " ++ operational FV3-GDAS chosen"               ;
        echo " "; set -x                                    ;
 #       gdasdir=${gdasdir:-${COMINgdas:?}/${cyc}}                   ;
-       gdasdir=${gdasdir:-${COMINgdas:?}/${cyc}/${COMPONENT}}    ;
+       gdasdir=${gdasdir:-${COMINgdas:?}}    ;
        gdasgfile=gdas.t${cyc}z.pgrb2.0p25.f                 ;
 
        vit_incr=${FHOUT_CYCLONE:-3}                        ;
@@ -207,7 +207,7 @@ case ${cmodel} in
        echo " ++ operational FV3-GFS chosen"               ;
        echo " "; set -x                                    ;
 #       gfsdir=${gfsdir:-${COMINgfs:?}/${cyc}}                     ;
-       gfsdir=${gfsdir:-${COMINgfs:?}/${cyc}/${COMPONENT}} ;
+       gfsdir=${gfsdir:-${COMINgfs:?}} ;
        gfsgfile=gfs.t${cyc}z.pgrb2.0p25.f                  ;
 
        vit_incr=${FHOUT_CYCLONE:-6}                        ;
@@ -642,9 +642,9 @@ then
   #synvitdir=${COMINgfs:?}/${cyc}/${COMPONENT}
   synvitdir=${COMINgfs:?}
   synvitfile=gfs.t${cyc}z.syndata.tcvitals.tm00
-  synvitold_dir=${synvitdir%.*}.${old_4ymd}/${old_hh}/${COMPONENT}
+  synvitold_dir="${COMINgfs/${PDY}\/${cyc}/${old_4ymd}/${old_hh}}"
   synvitold_file=gfs.t${old_hh}z.syndata.tcvitals.tm00
-  synvitfuture_dir=${synvitdir%.*}.${future_4ymd}/${future_hh}/${COMPONENT}
+  synvitfuture_dir="${COMINgfs/${PDY}\/${cyc}/${future_4ymd}/${future_hh}}"
   synvitfuture_file=gfs.t${future_hh}z.syndata.tcvitals.tm00
 else
 #  synvitdir=${COMROOT}/nam/prod/nam.${PDY}

--- a/ush/extrkr_tcv_gfs.sh
+++ b/ush/extrkr_tcv_gfs.sh
@@ -179,7 +179,7 @@ case ${cmodel} in
   gfs) set +x; echo " "                                    ;
        echo " ++ operational FV3-GFS chosen"               ;
        echo " "; set -x                                    ;
-       gfsdir=${gfsdir:-${COMINgfs:?}/${cyc}/${COMPONENT}}  ;
+       gfsdir=${gfsdir:-${COMINgfs:?}}  ;
        gfsgfile=gfs.t${cyc}z.pgrb2.0p25.f                  ;
 
        vit_incr=${FHOUT_CYCLONE:-6}                        ;
@@ -414,11 +414,11 @@ future_str="${future_ymd} ${future_hh}00"
 
 if [ ${modtyp} = 'global' ]
 then
-  synvitdir=${COMINgfs:?}/${cyc}/${COMPONENT}
+  synvitdir="${COMINgfs:?}"
   synvitfile=gfs.t${cyc}z.syndata.tcvitals.tm00
-  synvitold_dir=${synvitdir%.*}.${old_4ymd}/${old_hh}/${COMPONENT}
+  synvitold_dir="${COMINgfs/${PDY}\/${cyc}/${old_4ymd}/${old_hh}}"
   synvitold_file=gfs.t${old_hh}z.syndata.tcvitals.tm00
-  synvitfuture_dir=${synvitdir%.*}.${future_4ymd}/${future_hh}/${COMPONENT}
+  synvitfuture_dir="${COMINgfs/${PDY}\/${cyc}/${future_4ymd}/${future_hh}}"
   synvitfuture_file=gfs.t${future_hh}z.syndata.tcvitals.tm00
 else
 #  synvitdir=${COMROOT}/nam/prod/nam.${PDY}


### PR DESCRIPTION
The upcoming update to GFS v17 will substantially change the COM paths for the GFS package. When called within global workflow, `$COMINgfs` now contains the full path to the desired directories. This requires changes to how the look-behind and look-ahead are done. Now instead of constructing the path itself, the lookbehind and look-ahead now do a substitution of `${PDY}/${cyc}` with the new desired values for the other cycles.

Additional changes will be needed to the j-jobs to match the updated `$COMINgfs` pattern for GFS v17 in order to run this as a seperate system (as in ops). Also, not all GFS tracker jobs are currently available in the global workflow, so changes for FSU genesis have not been tested.

Additional changes will also be needed for GEFS v13, which is making similar changes to COM.

Refs: #1
Refs: NOAA-EMC/global-workflow#761