### PR TITLE
Migrate to Rocky8 installation of spack stack on Jet

### DIFF
--- a/scripts/exgdas_tc_track.sh
+++ b/scripts/exgdas_tc_track.sh
@@ -42,7 +42,7 @@ elif [[ -d /work ]] ; then
   machine=orion
   ${USHens_tracker}/extrkr_gfs.sh ${loopnum} ${cmodel} ${ymdh} ${pert} ${pertdir} #2>&1 >${outfile}
 
-elif [[ -d /lfs3 ]] ; then
+elif [[ -d /lfs5 ]] ; then
   # We are on NOAA Jet
   machine=jet
   ${USHens_tracker}/extrkr_gfs.sh ${loopnum} ${cmodel} ${ymdh} ${pert} ${pertdir} #2>&1 >${outfile}

--- a/scripts/exgfs_tc_genesis.sh
+++ b/scripts/exgfs_tc_genesis.sh
@@ -60,7 +60,7 @@ elif [[ -d /work ]] ; then
   machine=orion
   ${USHens_tracker}/extrkr_tcv_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}
 
-elif [[ -d /lfs3 ]] ; then
+elif [[ -d /lfs1 ]] ; then
   # We are on NOAA Jet
   machine=jet
   ${USHens_tracker}/extrkr_tcv_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}

--- a/scripts/exgfs_tc_genesis.sh
+++ b/scripts/exgfs_tc_genesis.sh
@@ -60,7 +60,7 @@ elif [[ -d /work ]] ; then
   machine=orion
   ${USHens_tracker}/extrkr_tcv_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}
 
-elif [[ -d /lfs1 ]] ; then
+elif [[ -d /lfs5 ]] ; then
   # We are on NOAA Jet
   machine=jet
   ${USHens_tracker}/extrkr_tcv_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}
@@ -125,7 +125,7 @@ elif [[ -d /work ]] ; then
   machine=orion
   ${USHens_tracker}/extrkr_gen_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}
 
-elif [[ -d /lfs1 ]] ; then
+elif [[ -d /lfs5 ]] ; then
   # We are on NOAA Jet
   machine=jet
   ${USHens_tracker}/extrkr_gen_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}

--- a/scripts/exgfs_tc_genesis.sh
+++ b/scripts/exgfs_tc_genesis.sh
@@ -125,7 +125,7 @@ elif [[ -d /work ]] ; then
   machine=orion
   ${USHens_tracker}/extrkr_gen_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}
 
-elif [[ -d /lfs3 ]] ; then
+elif [[ -d /lfs1 ]] ; then
   # We are on NOAA Jet
   machine=jet
   ${USHens_tracker}/extrkr_gen_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}

--- a/scripts/exgfs_tc_track.sh
+++ b/scripts/exgfs_tc_track.sh
@@ -44,7 +44,7 @@ elif [[ -d /work ]] ; then
   machine=orion
   ${USHens_tracker}/extrkr_gfs.sh ${loopnum} ${cmodel} ${ymdh} ${pert} ${pertdir} #2>&1 >${outfile}
 
-elif [[ -d /lfs1 ]] ; then
+elif [[ -d /lfs5 ]] ; then
   # We are on NOAA Jet
   machine=jet
   ${USHens_tracker}/extrkr_gfs.sh ${loopnum} ${cmodel} ${ymdh} ${pert} ${pertdir} #2>&1 >${outfile}

--- a/scripts/exgfs_tc_track.sh
+++ b/scripts/exgfs_tc_track.sh
@@ -44,7 +44,7 @@ elif [[ -d /work ]] ; then
   machine=orion
   ${USHens_tracker}/extrkr_gfs.sh ${loopnum} ${cmodel} ${ymdh} ${pert} ${pertdir} #2>&1 >${outfile}
 
-elif [[ -d /lfs3 ]] ; then
+elif [[ -d /lfs1 ]] ; then
   # We are on NOAA Jet
   machine=jet
   ${USHens_tracker}/extrkr_gfs.sh ${loopnum} ${cmodel} ${ymdh} ${pert} ${pertdir} #2>&1 >${outfile}

--- a/sorc/Module_ens_tracker.v1.1.15_for_Jet
+++ b/sorc/Module_ens_tracker.v1.1.15_for_Jet
@@ -1,26 +1,20 @@
 #%Module  for JET  ################################################
-setenv NCEPLIBS /mnt/lfs4/HFIP/hfv3gfs/nwprod/NCEPLIBS/lib
+module use /mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core
 
-module use /mnt/lfs4/HFIP/hfv3gfs/nwprod/NCEPLIBS/modulefiles
-module use /apps/modules/modulefamilies/intel
-module use /apps/modules/modulefamilies/intel_impi
+module load stack-intel/2021.5.0
+module load stack-intel-oneapi-mpi/2021.5.1
 
-module load intel/18.0.5.274
-module load impi/2018.4.274
-#module load nco/4.7.0
+module load jasper/2.0.32
+module load zlib/1.2.13
+module load libpng/1.6.37
+module load hdf5/1.14.0
+module load netcdf-c/4.9.2
+module load netcdf-fortran/4.6.1
+module load bacio/2.4.1
+module load w3emc/2.10.0
+module load w3nco/2.4.1
+module load sp/2.5.0
+module load ip/4.3.0
+module load sigio/2.3.2
+module load g2/3.4.5
 
-module load png/v1.2.44
-#module load w3emc/2.4.0
-module load w3nco/v2.0.6
-module load bacio/v2.0.2
-module load g2/v3.1.0
-
-module load z/v1.2.6
-module load jasper/v1.900.1
-module load sigio/v2.1.0
-module load sp/v2.0.2
-module load ip/v3.0.1
-
-module load hdf5_parallel/1.10.6
-module load netcdf_parallel/4.7.4
-module load w3emc_para/v2.4.0

--- a/sorc/build.sh
+++ b/sorc/build.sh
@@ -99,12 +99,15 @@ elif [[ -d /lfs1 ]] ; then
  module load Module_ens_tracker.v1.1.15_for_Jet
 
 machine=jet
-#export INC="${G2_INCd} -I${NETCDF}/include ${PNETCDF_INCLUDE} ${HDF5_INCLUDE_OPTS} "
-#export LIBS="${W3EMC_LIBd} ${W3NCO_LIBd} ${BACIO_LIB4} ${G2_LIBd} ${PNG_LIB} ${JASPER_LIB} ${Z_LIB} ${SP_LIBd} ${IP_LIBd} -L${NETCDF}/lib -lnetcdf ${PNETCDF_LD_OPTS} ${HDF5_LINK_OPTS}"
-export INC="${G2_INCd} -I${NETCDF}/include -I${HDF5}/include "
-export LIBS="${W3EMC_LIBd} ${W3NCO_LIBd} ${BACIO_LIB4} ${G2_LIBd} ${PNG_LIB} ${JASPER_LIB} ${Z_LIB} ${SP_LIBd} ${IP_LIBd} -L${NETCDF}/lib -lnetcdff -lnetcdf -L${HDF5}/lib -lhdf5_hl -lhdf5 "
-export LIBS_SUP="${W3EMC_LIBd} ${W3NCO_LIBd}"
-export LIBS_UK="${W3NCO_LIB4} ${BACIO_LIB4}"
+  #=============================
+  # April 2024, using spack-stack on Jet
+  # with spack-stack, lib names are lowerecased in environmental variables
+  export NETCDF_LDFLAGS="-L${netcdf_fortran_ROOT}/lib -lnetcdff -L${netcdf_c_ROOT}/lib -lnetcdf     -L${hdf5_ROOT}/lib     -lhdf5_hl -lhdf5 -L${zlib_ROOT}/lib -lz -ldl -lm"
+  export NETCDF_INCLUDES="-I${netcdf_c_ROOT}/include -I${netcdf_fortran_ROOT}/include -I${hdf5_ROOT}/include"
+  export INC="${G2_INCd} ${NETCDF_INCLUDES}"
+  export LIBS="${W3EMC_LIBd} ${W3NCO_LIBd} ${BACIO_LIB4} ${G2_LIBd} ${PNG_ROOT}/lib64/libpng.a     -L${jasper_ROOT}/lib64 -ljasper ${zlib_ROOT}/lib/libz.a ${NETCDF_LDFLAGS}"
+  export LIBS_SUP="${W3EMC_LIBd} ${W3NCO_LIBd}"
+  export LIBS_UK="${W3NCO_LIB4} ${BACIO_LIB4}"
 
 for dir in *.fd; do
 #for dir in gettrk_gfs.fd; do

--- a/sorc/build.sh
+++ b/sorc/build.sh
@@ -94,7 +94,7 @@ for dir in *.fd; do
   cd ..
 done
 
-elif [[ -d /lfs1 ]] ; then
+elif [[ -d /lfs5 ]] ; then
  # Load module file for Jet
  module load Module_ens_tracker.v1.1.15_for_Jet
 

--- a/sorc/build.sh
+++ b/sorc/build.sh
@@ -94,7 +94,7 @@ for dir in *.fd; do
   cd ..
 done
 
-elif [[ -d /lfs3 ]] ; then
+elif [[ -d /lfs1 ]] ; then
  # Load module file for Jet
  module load Module_ens_tracker.v1.1.15_for_Jet
 


### PR DESCRIPTION
# Description
- Update Jet module file to use Rocky8 installation of spack-stack;
- Update the build script to proerly detect Jet
- Update path to libraries and header files to use spack stack formats
- Jet has been upgraded to the Rocky8 Linux OS and present module file no longer works
  Resolves #5
  Refs NOAA-EMC/global-workflow#2377

This change affects only Jet.

# How has this been tested?
Cycled Global workflow experiments (48+ hours) on Jet at resolutions
- [x] 96/48 on xjet and kjet
- [x] 192/96 on kjet
- [x] 384/192 on kjet