### PR TITLE
Update TC Tracker to spack-stack 1.9.2 and port to Ursa

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 #=======================================================================
 
 cmake_minimum_required(VERSION 3.15)
-project( 
+project(
   HAFS_TOOLS
   LANGUAGES C Fortran)
 
@@ -28,7 +28,8 @@ find_package(Jasper REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(g2 REQUIRED)
 find_package(bacio REQUIRED)
-find_package(w3emc REQUIRED)
+# w3emc is only needed if using an older g2 library that does not include w3emc functionality.
+find_package(w3emc)
 
 add_subdirectory(sorc/gettrk_gfs.fd)
 add_subdirectory(sorc/ens_trak_ave.fd)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,13 @@ find_package(Jasper REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(g2 REQUIRED)
 find_package(bacio REQUIRED)
-# w3emc is only needed if using an older g2 library that does not include w3emc functionality.
-find_package(w3emc)
+set (USE_W3EMC FALSE)
+if(NOT g2_VERSION VERSION_GREATER_EQUAL "3.5.0")
+  message(STATUS "g2 version ${g2_VERSION} < 3.5.0, w3emc package is needed")
+  set(USE_W3EMC TRUE)
+endif()
+# Regardless, w3emc is required by g2.
+find_package(w3emc REQUIRED)
 
 add_subdirectory(sorc/gettrk_gfs.fd)
 add_subdirectory(sorc/ens_trak_ave.fd)

--- a/modulefiles/gaeac6.lua
+++ b/modulefiles/gaeac6.lua
@@ -43,9 +43,6 @@ load(pathJoin("g2", g2_ver))
 g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.13.0"
 load(pathJoin("g2tmpl", g2tmpl_ver))
 
-w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
-load(pathJoin("w3emc", w3emc_ver))
-
 sigio_ver=os.getenv("sigio_ver") or "2.3.3"
 load(pathJoin("sigio", sigio_ver))
 
@@ -58,6 +55,8 @@ load(pathJoin("wgrib2", wgrib2_ver))
 grib_util_ver=os.getenv("grib_util_ver") or "1.4.0"
 load(pathJoin("grib-util", grib_util_ver))
 
+unload("cray-libsci")
+
 setenv("CC", "cc")
 setenv("CXX", "CC")
 setenv("FC", "ftn")
@@ -65,4 +64,3 @@ setenv("CMAKE_C_COMPILER", "cc")
 setenv("CMAKE_CXX_COMPILER", "CC")
 setenv("CMAKE_Fortran_COMPILER", "ftn")
 setenv("CMAKE_Platform", "gaeac6")
-

--- a/modulefiles/gaeac6.lua
+++ b/modulefiles/gaeac6.lua
@@ -2,7 +2,7 @@ help([[
 loads TC_tracker modulefile and related set environment veriables on GAEA C6
 ]])
 
-prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/c6/spack-stack-1.9.1/envs/ue-intel-2023.2.0/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/c6/spack-stack-1.9.2/envs/ue-intel-2023.2.0/install/modulefiles/Core")
 
 stack_intel_ver=os.getenv("stack_intel_ver") or "2023.2.0"
 load(pathJoin("stack-intel", stack_intel_ver))

--- a/modulefiles/gaeac6.lua
+++ b/modulefiles/gaeac6.lua
@@ -2,18 +2,18 @@ help([[
 loads TC_tracker modulefile and related set environment veriables on GAEA C6
 ]])
 
-prepend_path("MODULEPATH", "/autofs/ncrc-svm1_proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env-c6/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/c6/spack-stack-1.9.1/envs/ue-intel-2023.2.0/install/modulefiles/Core")
 
 stack_intel_ver=os.getenv("stack_intel_ver") or "2023.2.0"
 load(pathJoin("stack-intel", stack_intel_ver))
 
-stack_mpich_ver=os.getenv("stack_mpich_ver") or "8.1.29"
+stack_mpich_ver=os.getenv("stack_mpich_ver") or "8.1.30"
 load(pathJoin("stack-cray-mpich", stack_mpich_ver))
 
 craype_ver=os.getenv("craype_ver") or "2.7.30"
 load(pathJoin("craype", craype_ver))
 
-cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+cmake_ver=os.getenv("cmake_ver") or "3.27.9"
 load(pathJoin("cmake", cmake_ver))
 
 jasper_ver=os.getenv("jasper_ver") or "2.0.32"
@@ -25,7 +25,7 @@ load(pathJoin("zlib", zlib_ver))
 libpng_ver=os.getenv("libpng_ver") or "1.6.37"
 load(pathJoin("libpng", libpng_ver))
 
-hdf5_ver=os.getenv("hdf5_ver") or "1.14.0"
+hdf5_ver=os.getenv("hdf5_ver") or "1.14.3"
 load(pathJoin("hdf5", hdf5_ver))
 
 netcdf_c_ver=os.getenv("netcdf_c_ver") or "4.9.2"
@@ -37,25 +37,25 @@ load(pathJoin("netcdf-fortran", netcdf_fortran_ver))
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 load(pathJoin("bacio", bacio_ver))
 
-g2_ver=os.getenv("g2_ver") or "3.4.5"
+g2_ver=os.getenv("g2_ver") or "3.5.1"
 load(pathJoin("g2", g2_ver))
 
-g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.10.2"
+g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.13.0"
 load(pathJoin("g2tmpl", g2tmpl_ver))
 
 w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
 load(pathJoin("w3emc", w3emc_ver))
 
-sigio_ver=os.getenv("sigio_ver") or "2.3.2"
+sigio_ver=os.getenv("sigio_ver") or "2.3.3"
 load(pathJoin("sigio", sigio_ver))
 
 prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 load(pathJoin("prod_util", prod_util_ver))
 
-wgrib2_ver=os.getenv("wgrib2_ver") or "2.0.8"
+wgrib2_ver=os.getenv("wgrib2_ver") or "3.6.0"
 load(pathJoin("wgrib2", wgrib2_ver))
 
-grib_util_ver=os.getenv("grib_util_ver") or "1.3.0"
+grib_util_ver=os.getenv("grib_util_ver") or "1.4.0"
 load(pathJoin("grib-util", grib_util_ver))
 
 setenv("CC", "cc")

--- a/modulefiles/hera.lua
+++ b/modulefiles/hera.lua
@@ -9,7 +9,7 @@ load("hpss")
 prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
 
 stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
-load(pathJoin("stack-intel", stack_oneapi_ver))
+load(pathJoin("stack-oneapi", stack_oneapi_ver))
 
 stack_impi_ver=os.getenv("stack_impi_ver") or "2021.13"
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))

--- a/modulefiles/hera.lua
+++ b/modulefiles/hera.lua
@@ -47,9 +47,6 @@ load(pathJoin("g2", g2_ver))
 g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.13.0"
 load(pathJoin("g2tmpl", g2tmpl_ver))
 
-w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
-load(pathJoin("w3emc", w3emc_ver))
-
 sigio_ver=os.getenv("sigio_ver") or "2.3.3"
 load(pathJoin("sigio", sigio_ver))
 

--- a/modulefiles/hera.lua
+++ b/modulefiles/hera.lua
@@ -6,18 +6,18 @@ prepend_path("MODULEPATH", "/contrib/sutils/modulefiles")
 load("sutils")
 load("hpss")
 
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
 
-stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
-load(pathJoin("stack-intel", stack_intel_ver))
+stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
+load(pathJoin("stack-intel", stack_oneapi_ver))
 
-stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"
+stack_impi_ver=os.getenv("stack_impi_ver") or "2021.13"
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
 
-python_ver=os.getenv("python_ver") or "3.10.13"
+python_ver=os.getenv("python_ver") or "3.11.7"
 load(pathJoin("python", python_ver))
 
-cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+cmake_ver=os.getenv("cmake_ver") or "3.27.9"
 load(pathJoin("cmake", cmake_ver))
 
 jasper_ver=os.getenv("jasper_ver") or "2.0.32"
@@ -29,7 +29,7 @@ load(pathJoin("zlib", zlib_ver))
 libpng_ver=os.getenv("libpng_ver") or "1.6.37"
 load(pathJoin("libpng", libpng_ver))
 
-hdf5_ver=os.getenv("hdf5_ver") or "1.14.0"
+hdf5_ver=os.getenv("hdf5_ver") or "1.14.3"
 load(pathJoin("hdf5", hdf5_ver))
 
 netcdf_c_ver=os.getenv("netcdf_c_ver") or "4.9.2"
@@ -41,30 +41,28 @@ load(pathJoin("netcdf-fortran", netcdf_fortran_ver))
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 load(pathJoin("bacio", bacio_ver))
 
-g2_ver=os.getenv("g2_ver") or "3.4.5"
+g2_ver=os.getenv("g2_ver") or "3.5.1"
 load(pathJoin("g2", g2_ver))
 
-g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.10.2"
+g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.13.0"
 load(pathJoin("g2tmpl", g2tmpl_ver))
 
 w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
 load(pathJoin("w3emc", w3emc_ver))
 
-sigio_ver=os.getenv("sigio_ver") or "2.3.2"
+sigio_ver=os.getenv("sigio_ver") or "2.3.3"
 load(pathJoin("sigio", sigio_ver))
 
-prod_util=os.getenv("prod_util_ver") or "2.1.1"
+prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 load(pathJoin("prod_util", prod_util_ver))
 
-wgrib2_ver=os.getenv("wgrib2_ver") or "2.0.8"
+wgrib2_ver=os.getenv("wgrib2_ver") or "3.6.0"
 load(pathJoin("wgrib2", wgrib2_ver))
 
-grib_util_ver=os.getenv("grib_util_ver") or "1.3.0"
+grib_util_ver=os.getenv("grib_util_ver") or "1.4.0"
 load(pathJoin("grib-util", grib_util_ver))
 
 setenv("CMAKE_C_COMPILER", "mpiicc")
 setenv("CMAKE_CXX_COMPILER", "mpiicpc")
 setenv("CMAKE_Fortran_COMPILER", "mpiifort")
 setenv("CMAKE_Platform", "hera.intel")
-
-

--- a/modulefiles/hercules.lua
+++ b/modulefiles/hercules.lua
@@ -5,16 +5,16 @@ loads hafs_tracker modulefile and related set environment veriables on Hercules
 load("contrib")
 load("noaatools") 
 
-prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.1.0/install/modulefiles/Core")
 
-stack_intel_ver=os.getenv("stack_intel_ver") or "2021.9.0"
-load(pathJoin("stack-intel", stack_intel_ver))
+stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
+load(pathJoin("stack-oneapi", stack_oneapi_ver))
 
-stack_impi_ver=os.getenv("stack_impi_ver") or "2021.9.0"
+stack_impi_ver=os.getenv("stack_impi_ver") or "2021.13"
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
 
-cmake_ver=os.getenv("cmake_ver") or "3.23.1"
-load(pathJoin("cmake", cmake_ver)) 
+cmake_ver=os.getenv("cmake_ver") or "3.27.9"
+load(pathJoin("cmake", cmake_ver))
 
 jasper_ver=os.getenv("jasper_ver") or "2.0.32"
 load(pathJoin("jasper", jasper_ver))
@@ -25,7 +25,7 @@ load(pathJoin("zlib", zlib_ver))
 libpng_ver=os.getenv("libpng_ver") or "1.6.37"
 load(pathJoin("libpng", libpng_ver))
 
-hdf5_ver=os.getenv("hdf5_ver") or "1.14.0"
+hdf5_ver=os.getenv("hdf5_ver") or "1.14.3"
 load(pathJoin("hdf5", hdf5_ver))
 
 netcdf_c_ver=os.getenv("netcdf_c_ver") or "4.9.2"
@@ -37,20 +37,28 @@ load(pathJoin("netcdf-fortran", netcdf_fortran_ver))
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 load(pathJoin("bacio", bacio_ver))
 
-g2_ver=os.getenv("g2_ver") or "3.4.5"
+g2_ver=os.getenv("g2_ver") or "3.5.1"
 load(pathJoin("g2", g2_ver))
 
-g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.10.2"
+g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.13.0"
 load(pathJoin("g2tmpl", g2tmpl_ver))
 
 w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
 load(pathJoin("w3emc", w3emc_ver))
 
-sigio_ver=os.getenv("sigio_ver") or "2.3.2"
+sigio_ver=os.getenv("sigio_ver") or "2.3.3"
 load(pathJoin("sigio", sigio_ver))
+
+prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
+load(pathJoin("prod_util", prod_util_ver))
+
+wgrib2_ver=os.getenv("wgrib2_ver") or "3.6.0"
+load(pathJoin("wgrib2", wgrib2_ver))
+
+grib_util_ver=os.getenv("grib_util_ver") or "1.4.0"
+load(pathJoin("grib-util", grib_util_ver))
 
 setenv("CMAKE_C_COMPILER", "mpiicc")
 setenv("CMAKE_CXX_COMPILER", "mpiicpc")
 setenv("CMAKE_Fortran_COMPILER", "mpiifort")
 setenv("CMAKE_Platform", "hercules.intel")
-

--- a/modulefiles/hercules.lua
+++ b/modulefiles/hercules.lua
@@ -5,7 +5,7 @@ loads hafs_tracker modulefile and related set environment veriables on Hercules
 load("contrib")
 load("noaatools") 
 
-prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.1.0/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.1.0/install/modulefiles/Core")
 
 stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
 load(pathJoin("stack-oneapi", stack_oneapi_ver))

--- a/modulefiles/hercules.lua
+++ b/modulefiles/hercules.lua
@@ -43,9 +43,6 @@ load(pathJoin("g2", g2_ver))
 g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.13.0"
 load(pathJoin("g2tmpl", g2tmpl_ver))
 
-w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
-load(pathJoin("w3emc", w3emc_ver))
-
 sigio_ver=os.getenv("sigio_ver") or "2.3.3"
 load(pathJoin("sigio", sigio_ver))
 

--- a/modulefiles/jet.lua
+++ b/modulefiles/jet.lua
@@ -44,9 +44,6 @@ load(pathJoin("g2", g2_ver))
 g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.10.2"
 load(pathJoin("g2tmpl", g2tmpl_ver))
 
-w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
-load(pathJoin("w3emc", w3emc_ver))
-
 sigio_ver=os.getenv("sigio_ver") or "2.3.2"
 load(pathJoin("sigio", sigio_ver))
 

--- a/modulefiles/orion.lua
+++ b/modulefiles/orion.lua
@@ -5,7 +5,7 @@ loads TC_tracker modulefile and related set environment veriables on Orion
 load("contrib")
 load("noaatools") 
 
-prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.1.0/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.1.0/install/modulefiles/Core")
 
 stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
 load(pathJoin("stack-oneapi", stack_oneapi_ver))

--- a/modulefiles/orion.lua
+++ b/modulefiles/orion.lua
@@ -5,16 +5,16 @@ loads TC_tracker modulefile and related set environment veriables on Orion
 load("contrib")
 load("noaatools") 
 
-prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/unified-env-rocky9/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.1.0/install/modulefiles/Core")
 
-stack_intel_ver=os.getenv("stack_intel_ver") or "2021.9.0"
-load(pathJoin("stack-intel", stack_intel_ver))
+stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
+load(pathJoin("stack-oneapi", stack_oneapi_ver))
 
-stack_impi_ver=os.getenv("stack_impi_ver") or "2021.9.0"
+stack_impi_ver=os.getenv("stack_impi_ver") or "2021.13"
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
 
-cmake_ver=os.getenv("cmake_ver") or "3.23.1"
-load(pathJoin("cmake", cmake_ver)) 
+cmake_ver=os.getenv("cmake_ver") or "3.27.9"
+load(pathJoin("cmake", cmake_ver))
 
 jasper_ver=os.getenv("jasper_ver") or "2.0.32"
 load(pathJoin("jasper", jasper_ver))
@@ -25,7 +25,7 @@ load(pathJoin("zlib", zlib_ver))
 libpng_ver=os.getenv("libpng_ver") or "1.6.37"
 load(pathJoin("libpng", libpng_ver))
 
-hdf5_ver=os.getenv("hdf5_ver") or "1.14.0"
+hdf5_ver=os.getenv("hdf5_ver") or "1.14.3"
 load(pathJoin("hdf5", hdf5_ver))
 
 netcdf_c_ver=os.getenv("netcdf_c_ver") or "4.9.2"
@@ -37,29 +37,28 @@ load(pathJoin("netcdf-fortran", netcdf_fortran_ver))
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 load(pathJoin("bacio", bacio_ver))
 
-g2_ver=os.getenv("g2_ver") or "3.4.5"
+g2_ver=os.getenv("g2_ver") or "3.5.1"
 load(pathJoin("g2", g2_ver))
 
-g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.10.2"
+g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.13.0"
 load(pathJoin("g2tmpl", g2tmpl_ver))
 
 w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
 load(pathJoin("w3emc", w3emc_ver))
 
-sigio_ver=os.getenv("sigio_ver") or "2.3.2"
+sigio_ver=os.getenv("sigio_ver") or "2.3.3"
 load(pathJoin("sigio", sigio_ver))
 
 prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 load(pathJoin("prod_util", prod_util_ver))
 
-wgrib2_ver=os.getenv("wgrib2_ver") or "2.0.8"
+wgrib2_ver=os.getenv("wgrib2_ver") or "3.6.0"
 load(pathJoin("wgrib2", wgrib2_ver))
 
-grib_util_ver=os.getenv("grib_util_ver") or "1.3.0"
+grib_util_ver=os.getenv("grib_util_ver") or "1.4.0"
 load(pathJoin("grib-util", grib_util_ver))
 
 setenv("CMAKE_C_COMPILER", "mpiicc")
 setenv("CMAKE_CXX_COMPILER", "mpiicpc")
 setenv("CMAKE_Fortran_COMPILER", "mpiifort")
 setenv("CMAKE_Platform", "orion.intel")
-

--- a/modulefiles/orion.lua
+++ b/modulefiles/orion.lua
@@ -43,9 +43,6 @@ load(pathJoin("g2", g2_ver))
 g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.13.0"
 load(pathJoin("g2tmpl", g2tmpl_ver))
 
-w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
-load(pathJoin("w3emc", w3emc_ver))
-
 sigio_ver=os.getenv("sigio_ver") or "2.3.3"
 load(pathJoin("sigio", sigio_ver))
 

--- a/modulefiles/ursa.lua
+++ b/modulefiles/ursa.lua
@@ -1,0 +1,66 @@
+help([[
+loads TC_tracker modulefile and related set environment veriables on Ursa
+]])
+
+load("hpss")
+
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
+
+stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
+load(pathJoin("stack-intel", stack_oneapi_ver))
+
+stack_impi_ver=os.getenv("stack_impi_ver") or "2021.13"
+load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
+
+python_ver=os.getenv("python_ver") or "3.11.7"
+load(pathJoin("python", python_ver))
+
+cmake_ver=os.getenv("cmake_ver") or "3.27.9"
+load(pathJoin("cmake", cmake_ver))
+
+jasper_ver=os.getenv("jasper_ver") or "2.0.32"
+load(pathJoin("jasper", jasper_ver))
+
+zlib_ver=os.getenv("zlib_ver") or "1.2.13"
+load(pathJoin("zlib", zlib_ver))
+
+libpng_ver=os.getenv("libpng_ver") or "1.6.37"
+load(pathJoin("libpng", libpng_ver))
+
+hdf5_ver=os.getenv("hdf5_ver") or "1.14.3"
+load(pathJoin("hdf5", hdf5_ver))
+
+netcdf_c_ver=os.getenv("netcdf_c_ver") or "4.9.2"
+load(pathJoin("netcdf-c", netcdf_c_ver))
+
+netcdf_fortran_ver=os.getenv("netcdf_fortran_ver") or "4.6.1"
+load(pathJoin("netcdf-fortran", netcdf_fortran_ver))
+
+bacio_ver=os.getenv("bacio_ver") or "2.4.1"
+load(pathJoin("bacio", bacio_ver))
+
+g2_ver=os.getenv("g2_ver") or "3.5.1"
+load(pathJoin("g2", g2_ver))
+
+g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.13.0"
+load(pathJoin("g2tmpl", g2tmpl_ver))
+
+w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
+load(pathJoin("w3emc", w3emc_ver))
+
+sigio_ver=os.getenv("sigio_ver") or "2.3.3"
+load(pathJoin("sigio", sigio_ver))
+
+prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
+load(pathJoin("prod_util", prod_util_ver))
+
+wgrib2_ver=os.getenv("wgrib2_ver") or "3.6.0"
+load(pathJoin("wgrib2", wgrib2_ver))
+
+grib_util_ver=os.getenv("grib_util_ver") or "1.4.0"
+load(pathJoin("grib-util", grib_util_ver))
+
+setenv("CMAKE_C_COMPILER", "mpiicc")
+setenv("CMAKE_CXX_COMPILER", "mpiicpc")
+setenv("CMAKE_Fortran_COMPILER", "mpiifort")
+setenv("CMAKE_Platform", "hera.intel")

--- a/modulefiles/ursa.lua
+++ b/modulefiles/ursa.lua
@@ -1,5 +1,5 @@
 help([[
-loads TC_tracker modulefile and related set environment veriables on Ursa
+loads TC_tracker modulefile and related set environment variables on Ursa
 ]])
 
 prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")

--- a/modulefiles/ursa.lua
+++ b/modulefiles/ursa.lua
@@ -2,8 +2,6 @@ help([[
 loads TC_tracker modulefile and related set environment veriables on Ursa
 ]])
 
-load("hpss")
-
 prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
 
 stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"

--- a/modulefiles/ursa.lua
+++ b/modulefiles/ursa.lua
@@ -43,9 +43,6 @@ load(pathJoin("g2", g2_ver))
 g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.13.0"
 load(pathJoin("g2tmpl", g2tmpl_ver))
 
-w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
-load(pathJoin("w3emc", w3emc_ver))
-
 sigio_ver=os.getenv("sigio_ver") or "2.3.3"
 load(pathJoin("sigio", sigio_ver))
 

--- a/modulefiles/ursa.lua
+++ b/modulefiles/ursa.lua
@@ -7,7 +7,7 @@ load("hpss")
 prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
 
 stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
-load(pathJoin("stack-intel", stack_oneapi_ver))
+load(pathJoin("stack-oneapi", stack_oneapi_ver))
 
 stack_impi_ver=os.getenv("stack_impi_ver") or "2021.13"
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))

--- a/modulefiles/wcoss2.lua
+++ b/modulefiles/wcoss2.lua
@@ -39,10 +39,10 @@ load(pathJoin("hdf5", hdf5_ver))
 netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
 load(pathJoin("netcdf", netcdf_ver))
 
-g2_ver=os.getenv("g2_ver") or "3.4.5"
+g2_ver=os.getenv("g2_ver") or "3.5.1"
 load(pathJoin("g2", g2_ver))
 
-w3emc_ver=os.getenv("w3emc_ver") or "2.9.1"
+w3emc_ver=os.getenv("w3emc_ver") or "2.12.0"
 load(pathJoin("w3emc", w3emc_ver))
 
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"
@@ -64,4 +64,3 @@ setenv("CMAKE_C_COMPILER", "cc")
 setenv("CMAKE_CXX_COMPILER", "CC")
 setenv("CMAKE_Fortran_COMPILER", "ftn")
 setenv("CMAKE_Platform", "wcoss2")
-

--- a/modulefiles/wcoss2.lua
+++ b/modulefiles/wcoss2.lua
@@ -42,9 +42,6 @@ load(pathJoin("netcdf", netcdf_ver))
 g2_ver=os.getenv("g2_ver") or "3.5.1"
 load(pathJoin("g2", g2_ver))
 
-w3emc_ver=os.getenv("w3emc_ver") or "2.12.0"
-load(pathJoin("w3emc", w3emc_ver))
-
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 load(pathJoin("bacio", bacio_ver))
 

--- a/modulefiles/wcoss2.lua
+++ b/modulefiles/wcoss2.lua
@@ -42,6 +42,9 @@ load(pathJoin("netcdf", netcdf_ver))
 g2_ver=os.getenv("g2_ver") or "3.5.1"
 load(pathJoin("g2", g2_ver))
 
+w3emc_ver=os.getenv("w3emc_ver") or "2.9.1"
+load(pathJoin("w3emc", w3emc_ver))
+
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 load(pathJoin("bacio", bacio_ver))
 

--- a/scripts/exgfs_tc_genesis.sh
+++ b/scripts/exgfs_tc_genesis.sh
@@ -42,7 +42,7 @@ mkdir -p $pertdir
 
 if [[ -d /scratch3 ]] ; then
   # We are on NOAA Hera or Ursa
-  machine=hera
+  machine=ursa
   ${USHens_tracker}/extrkr_tcv_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}
 
 elif [[ -d /work ]] ; then
@@ -102,7 +102,7 @@ mkdir -p $pertdir
 
 if [[ -d /scratch3 ]] ; then
   # We are on NOAA Hera or Ursa
-  machine=hera
+  machine=ursa
   ${USHens_tracker}/extrkr_gen_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}
 
 elif [[ -d /work ]] ; then

--- a/scripts/exgfs_tc_genesis.sh
+++ b/scripts/exgfs_tc_genesis.sh
@@ -40,13 +40,13 @@ mkdir -p $pertdir
 
 #outfile=${pertdir}/trkr.${regtype}.${cmodel}.${pert}.${ymdh}.out
 
-if [[ -d /scratch2 ]] ; then
-  # We are on NOAA Hera
+if [[ -d /scratch3 ]] ; then
+  # We are on NOAA Hera or Ursa
   machine=hera
   ${USHens_tracker}/extrkr_tcv_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}
 
 elif [[ -d /work ]] ; then
-  # We are on MSU Orion
+  # We are on MSU Orion or Hercules
   machine=orion
   ${USHens_tracker}/extrkr_tcv_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}
 
@@ -100,13 +100,13 @@ mkdir -p $pertdir
 
 #outfile=${pertdir}/trkr.${regtype}.${cmodel}.${pert}.${ymdh}.out
 
-if [[ -d /scratch2 ]] ; then
-  # We are on NOAA Hera
+if [[ -d /scratch3 ]] ; then
+  # We are on NOAA Hera or Ursa
   machine=hera
   ${USHens_tracker}/extrkr_gen_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}
 
 elif [[ -d /work ]] ; then
-  # We are on MSU Orion
+  # We are on MSU Orion or Hercules
   machine=orion
   ${USHens_tracker}/extrkr_gen_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}
 

--- a/sorc/build_tracker.sh
+++ b/sorc/build_tracker.sh
@@ -27,7 +27,7 @@ cd build
 
 cmake .. -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER} -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
 
-make -j 8 VERBOSE=2
+make -j ${BUILD_JOBS:-8} VERBOSE=2
 make install
 
 cd ..

--- a/sorc/ens_trak_ave.fd/CMakeLists.txt
+++ b/sorc/ens_trak_ave.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/ens_trak_ave.fd/CMakeLists.txt
+++ b/sorc/ens_trak_ave.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/ens_trak_ave_2d.fd/CMakeLists.txt
+++ b/sorc/ens_trak_ave_2d.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/ens_trak_ave_2d.fd/CMakeLists.txt
+++ b/sorc/ens_trak_ave_2d.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/filter_cmc.fd/CMakeLists.txt
+++ b/sorc/filter_cmc.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/filter_cmc.fd/CMakeLists.txt
+++ b/sorc/filter_cmc.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/filter_ecmwf.fd/CMakeLists.txt
+++ b/sorc/filter_ecmwf.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,6 +50,10 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})
 

--- a/sorc/filter_ecmwf.fd/CMakeLists.txt
+++ b/sorc/filter_ecmwf.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/filter_gfs.fd/CMakeLists.txt
+++ b/sorc/filter_gfs.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,6 +50,10 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})
 

--- a/sorc/filter_gfs.fd/CMakeLists.txt
+++ b/sorc/filter_gfs.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/filter_navgem.fd/CMakeLists.txt
+++ b/sorc/filter_navgem.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/filter_navgem.fd/CMakeLists.txt
+++ b/sorc/filter_navgem.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/filter_ukmet.fd/CMakeLists.txt
+++ b/sorc/filter_ukmet.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/filter_ukmet.fd/CMakeLists.txt
+++ b/sorc/filter_ukmet.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/gettrk_g1.fd/CMakeLists.txt
+++ b/sorc/gettrk_g1.fd/CMakeLists.txt
@@ -37,7 +37,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -52,5 +51,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/gettrk_g1.fd/CMakeLists.txt
+++ b/sorc/gettrk_g1.fd/CMakeLists.txt
@@ -29,7 +29,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -47,7 +46,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/gettrk_g2.fd/CMakeLists.txt
+++ b/sorc/gettrk_g2.fd/CMakeLists.txt
@@ -31,7 +31,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -49,7 +48,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/gettrk_g2.fd/CMakeLists.txt
+++ b/sorc/gettrk_g2.fd/CMakeLists.txt
@@ -39,7 +39,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -54,5 +53,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/gettrk_g2.fd/cwaitfor.c
+++ b/sorc/gettrk_g2.fd/cwaitfor.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
+#include <time.h>
 
 void c_run_command(int *retval,char *cmd) {
   *retval=system(cmd);

--- a/sorc/gettrk_gen_g1.fd/CMakeLists.txt
+++ b/sorc/gettrk_gen_g1.fd/CMakeLists.txt
@@ -31,7 +31,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -49,7 +48,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/gettrk_gen_g1.fd/CMakeLists.txt
+++ b/sorc/gettrk_gen_g1.fd/CMakeLists.txt
@@ -39,7 +39,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -54,5 +53,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/gettrk_gen_g1.fd/cwaitfor.c
+++ b/sorc/gettrk_gen_g1.fd/cwaitfor.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
+#include <time.h>
 
 void c_run_command(int *retval,char *cmd) {
   *retval=system(cmd);

--- a/sorc/gettrk_gen_g2.fd/CMakeLists.txt
+++ b/sorc/gettrk_gen_g2.fd/CMakeLists.txt
@@ -31,7 +31,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -49,7 +48,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/gettrk_gen_g2.fd/CMakeLists.txt
+++ b/sorc/gettrk_gen_g2.fd/CMakeLists.txt
@@ -39,7 +39,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -54,5 +53,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/gettrk_gen_g2.fd/cwaitfor.c
+++ b/sorc/gettrk_gen_g2.fd/cwaitfor.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
+#include <time.h>
 
 void c_run_command(int *retval,char *cmd) {
   *retval=system(cmd);

--- a/sorc/gettrk_gen_gfs.fd/CMakeLists.txt
+++ b/sorc/gettrk_gen_gfs.fd/CMakeLists.txt
@@ -31,7 +31,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -49,7 +48,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/gettrk_gen_gfs.fd/CMakeLists.txt
+++ b/sorc/gettrk_gen_gfs.fd/CMakeLists.txt
@@ -39,7 +39,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -54,5 +53,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/gettrk_gen_gfs.fd/cwaitfor.c
+++ b/sorc/gettrk_gen_gfs.fd/cwaitfor.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
+#include <time.h>
 
 void c_run_command(int *retval,char *cmd) {
   *retval=system(cmd);

--- a/sorc/gettrk_gfs.fd/CMakeLists.txt
+++ b/sorc/gettrk_gfs.fd/CMakeLists.txt
@@ -31,7 +31,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -49,7 +48,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/gettrk_gfs.fd/CMakeLists.txt
+++ b/sorc/gettrk_gfs.fd/CMakeLists.txt
@@ -39,7 +39,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -54,5 +53,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/gettrk_gfs.fd/cwaitfor.c
+++ b/sorc/gettrk_gfs.fd/cwaitfor.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
+#include <time.h>
 
 void c_run_command(int *retval,char *cmd) {
   *retval=system(cmd);

--- a/sorc/leadtime.fd/CMakeLists.txt
+++ b/sorc/leadtime.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/leadtime.fd/CMakeLists.txt
+++ b/sorc/leadtime.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -39,16 +39,11 @@ elif [[ -d /work2/noaa ]]; then
   # We are on MSU Orion or Hercules
   mount=$(findmnt -n -o SOURCE /home)
   if [[ ${mount} =~ "hercules" ]]; then
-    MACHINE_ID=hercules
+    target=hercules
   else
-    MACHINE_ID=orion
+    target=orion
   fi
-    target=orion || hercules
     module purge
-    module use /apps/modulefiles/core
-    module use /apps/contrib/modulefiles
-    module use /apps/contrib/NCEPLIBS/lib/modulefiles
-    module use /apps/contrib/NCEPLIBS/orion/modulefiles
 elif [[ -d /gpfs/f5 ]]; then
   # We are on GAEAC5.
   target=gaeac5

--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -27,13 +27,14 @@ if [[ -d /lfs5 ]] ; then
     fi
     target=jet
     module purge
-elif [[ -d /scratch1/NCEPDEV ]] ; then
-    # We are on NOAA Hera
-    if ( ! eval module help > /dev/null 2>&1 ) ; then
-        echo load the module command 1>&2
-        source /apps/lmod/lmod/init/$__ms_shell
+elif [[ -d /scratch3/NCEPDEV ]] ; then
+    # We are on NOAA Hera or Ursa
+    mount=$(findmnt -n -o SOURCE /home)
+    if [[ ${mount} =~ "ursa" ]]; then
+      target=ursa
+    else
+      target=hera
     fi
-    target=hera
     module purge
 elif [[ -d /work2/noaa ]]; then
   # We are on MSU Orion or Hercules

--- a/sorc/ncep_tcv_cmc.fd/CMakeLists.txt
+++ b/sorc/ncep_tcv_cmc.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/ncep_tcv_cmc.fd/CMakeLists.txt
+++ b/sorc/ncep_tcv_cmc.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/ncep_tcv_ecmwf.fd/CMakeLists.txt
+++ b/sorc/ncep_tcv_ecmwf.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/ncep_tcv_ecmwf.fd/CMakeLists.txt
+++ b/sorc/ncep_tcv_ecmwf.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/ncep_tcv_gfs.fd/CMakeLists.txt
+++ b/sorc/ncep_tcv_gfs.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/ncep_tcv_gfs.fd/CMakeLists.txt
+++ b/sorc/ncep_tcv_gfs.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/ncep_tcv_navgem.fd/CMakeLists.txt
+++ b/sorc/ncep_tcv_navgem.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/ncep_tcv_navgem.fd/CMakeLists.txt
+++ b/sorc/ncep_tcv_navgem.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/ncep_tcv_ukmet.fd/CMakeLists.txt
+++ b/sorc/ncep_tcv_ukmet.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/ncep_tcv_ukmet.fd/CMakeLists.txt
+++ b/sorc/ncep_tcv_ukmet.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/readprob.fd/CMakeLists.txt
+++ b/sorc/readprob.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/readprob.fd/CMakeLists.txt
+++ b/sorc/readprob.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/readprobLL.fd/CMakeLists.txt
+++ b/sorc/readprobLL.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/readprobLL.fd/CMakeLists.txt
+++ b/sorc/readprobLL.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/readtcv.fd/CMakeLists.txt
+++ b/sorc/readtcv.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/readtcv.fd/CMakeLists.txt
+++ b/sorc/readtcv.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/rhum_g2.fd/CMakeLists.txt
+++ b/sorc/rhum_g2.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/rhum_g2.fd/CMakeLists.txt
+++ b/sorc/rhum_g2.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/supvit_g1.fd/CMakeLists.txt
+++ b/sorc/supvit_g1.fd/CMakeLists.txt
@@ -37,7 +37,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -52,5 +51,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/supvit_g1.fd/CMakeLists.txt
+++ b/sorc/supvit_g1.fd/CMakeLists.txt
@@ -29,7 +29,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -47,7 +46,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/supvit_g2.fd/CMakeLists.txt
+++ b/sorc/supvit_g2.fd/CMakeLists.txt
@@ -37,7 +37,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -52,5 +51,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/supvit_g2.fd/CMakeLists.txt
+++ b/sorc/supvit_g2.fd/CMakeLists.txt
@@ -29,7 +29,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -47,7 +46,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/tave_g1.fd/CMakeLists.txt
+++ b/sorc/tave_g1.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/tave_g1.fd/CMakeLists.txt
+++ b/sorc/tave_g1.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/tave_g2.fd/CMakeLists.txt
+++ b/sorc/tave_g2.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/tave_g2.fd/CMakeLists.txt
+++ b/sorc/tave_g2.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/ukmet.fd/CMakeLists.txt
+++ b/sorc/ukmet.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/ukmet.fd/CMakeLists.txt
+++ b/sorc/ukmet.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/ushear_g1.fd/CMakeLists.txt
+++ b/sorc/ushear_g1.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/ushear_g1.fd/CMakeLists.txt
+++ b/sorc/ushear_g1.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/ushear_g2.fd/CMakeLists.txt
+++ b/sorc/ushear_g2.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/ushear_g2.fd/CMakeLists.txt
+++ b/sorc/ushear_g2.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/vint_g1.fd/CMakeLists.txt
+++ b/sorc/vint_g1.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/vint_g1.fd/CMakeLists.txt
+++ b/sorc/vint_g1.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/vint_g2.fd/CMakeLists.txt
+++ b/sorc/vint_g2.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/vint_g2.fd/CMakeLists.txt
+++ b/sorc/vint_g2.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})

--- a/sorc/wsr_ecmwfens.fd/CMakeLists.txt
+++ b/sorc/wsr_ecmwfens.fd/CMakeLists.txt
@@ -28,7 +28,6 @@ IF(DEFINED hwrf_g2_inc)
 ELSE()
   target_include_directories(
   ${exe_name} PUBLIC
-  w3emc_d
   g2_d
   sigio_4)
 ENDIF()
@@ -46,7 +45,6 @@ ELSE()
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   g2::g2_d
   bacio::bacio_4
   ${JASPER_LIBRARIES}

--- a/sorc/wsr_ecmwfens.fd/CMakeLists.txt
+++ b/sorc/wsr_ecmwfens.fd/CMakeLists.txt
@@ -36,7 +36,6 @@ IF(DEFINED hwrf_g2_lib)
   target_link_libraries(
   ${exe_name}
   NetCDF::NetCDF_Fortran
-  w3emc::w3emc_d
   bacio::bacio_4
   ${hwrf_g2_lib}
   ${JASPER_LIBRARIES}
@@ -51,5 +50,9 @@ ELSE()
   ${PNG_LIBRARIES})
 ENDIF()
 
+
+if(USE_W3EMC)
+  target_link_libraries(${exe_name} w3emc::w3emc_d)
+endif()
 
 install(TARGETS ${exe_name} DESTINATION ${exec_dir})


### PR DESCRIPTION
This updates the module files on all RDHPCS platforms to spack-stack 1.9.2 and updates g2 on WCOSS2 to incorporate w3emc functionality.

Resolves #11 