### PR TITLE
Update modules on WCOSS2

### DIFF
--- a/modulefiles/wcoss2.lua
+++ b/modulefiles/wcoss2.lua
@@ -33,16 +33,19 @@ libjpeg_ver=os.getenv("libjpeg_ver") or "9c"
 load(pathJoin("libjpeg", libjpeg_ver))
 setenv("JPEG_LIBRARIES", "/apps/spack/libjpeg/9c/intel/19.1.3.304/jkr3isi257ktoouprwaxcn4twtye747z/lib")
 
-hdf5_ver=os.getenv("hdf5_ver") or "1.10.6"
-load(pathJoin("hdf5", hdf5_ver))
+hdf5_ver=os.getenv("hdf5_ver") or "1.14.0"
+load(pathJoin("hdf5-D", hdf5_ver))
 
-netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
-load(pathJoin("netcdf", netcdf_ver))
+pnetcdf_ver=os.getenv("pnetcdf_ver") or "1.12.2"
+load(pathJoin("pnetcdf-D", pnetcdf_ver))
+
+netcdf_ver=os.getenv("netcdf_ver") or "4.9.2"
+load(pathJoin("netcdf-D", netcdf_ver))
 
 g2_ver=os.getenv("g2_ver") or "3.5.1"
 load(pathJoin("g2", g2_ver))
 
-w3emc_ver=os.getenv("w3emc_ver") or "2.9.1"
+w3emc_ver=os.getenv("w3emc_ver") or "2.12.0"
 load(pathJoin("w3emc", w3emc_ver))
 
 bacio_ver=os.getenv("bacio_ver") or "2.4.1"


### PR DESCRIPTION
This updates the modulefiles on WCOSS2 to match the modules for other global-workflow repositories and spack-stack 1.9.2.