### PR TITLE
Introduce/update noaacloud machine detection logic

### DIFF
--- a/scripts/exgfs_tc_genesis.sh
+++ b/scripts/exgfs_tc_genesis.sh
@@ -65,6 +65,19 @@ elif [[ -d /gpfs/f6 ]] ; then
   machine=gaeac6
   ${USHens_tracker}/extrkr_tcv_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}
 
+elif [[ ! -z "${PW_CSP:+x}" ]]; then
+   case "${PW_CSP}" in
+      "aws" | "google" | "azure")
+        # We are on NOAA cloud
+	machine=noaacloud
+        ${USHens_tracker}/extrkr_tcv_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}
+	;;
+      *)
+        echo Job failed: unknown platform 1>&2
+        err_exit "FAILED ${jobid} - ERROR IN unknown platform - ABNORMAL EXIT"
+        ;;
+   esac
+
 else
   export machine=unknown
   echo Job failed: unknown platform 1>&2
@@ -124,6 +137,19 @@ elif [[ -d /gpfs/f6 ]] ; then
   # We are on NOAA gaeac6
   machine=gaeac6
   ${USHens_tracker}/extrkr_gen_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}
+
+elif [[ ! -z "${PW_CSP:+x}" ]]; then
+   case "${PW_CSP}" in
+      "aws" | "google" | "azure")
+        # We are on NOAA cloud
+        machine=noaacloud
+        ${USHens_tracker}/extrkr_gen_gfs.sh ${loopnum} ${cmodel} ${pert} ${pertdir} #2>&1 >${outfile}
+	;;
+      *)
+        echo Job failed: unknown platform 1>&2
+        err_exit "FAILED ${jobid} - ERROR IN unknown platform - ABNORMAL EXIT"
+        ;;
+   esac
 
 else
   export machine=unknown

--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -19,19 +19,6 @@ fi
 target=""
 USERNAME=`echo $LOGNAME | awk '{ print tolower($0)'}`
 
-# Check env var PW_CSP for supported cloud service provider
-if [[ ! -z "${PW_CSP:+x}" ]]; then
-   case "${PW_CSP}" in
-      "aws" | "google" | "azure") 
-        # We are on NOAA cloud
-        target=noaacloud 
-        ;;
-      *) 
-        echo "WARNING: ${PW_CSP} IS UNKNOWN CSP" 1>&2 
-        ;;
-   esac
-fi
-
 if [[ -d /lfs5 ]] ; then
      # We are on NOAA Jet
     if ( ! eval module help > /dev/null 2>&1 ) ; then
@@ -67,6 +54,16 @@ elif [[ -d /gpfs/f6 ]]; then
 elif [[ -d /lfs/h1 && -d /lfs/h2 ]] ; then
     target=wcoss2
     . $MODULESHOME/init/sh
+elif [[ ! -z "${PW_CSP:+x}" ]]; then
+   case "${PW_CSP}" in
+      "aws" | "google" | "azure")
+        # We are on NOAA cloud
+        target=noaacloud
+        ;;
+      *)
+        echo "WARNING: ${PW_CSP} IS UNKNOWN CSP" 1>&2
+        ;;
+   esac
 else
     echo WARNING: UNKNOWN PLATFORM 1>&2
 fi


### PR DESCRIPTION
This PR completes porting TC_tracker to noaacloud by introducing CSP detection logic to the various machine identifier blocks. Furthermore, the previously introduced noaacloud check in `machine-setup.sh` was moved to main if-block to avoid the `WARNING: UNKNOWN PLATFORM` statement from being printed in the case of being on noaalcoud.

Resolves #14 